### PR TITLE
Changing `RUN export` to `ENV` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN sudo wget "https://storage.googleapis.com/kubernetes-release/release/$(curl 
 RUN sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc && \
     sudo chmod +x /usr/local/bin/mc
 ENV PYTHONPATH="${PYTHONPATH}:/home/coder/.local/bin"
-ENV PATH="/home/coder/.local/bin:${$PATH}"
+ENV PATH="/home/coder/.local/bin:${PATH}"
 ADD requirements.txt /home/coder/requirements.txt
 RUN pip3 install --upgrade -r /home/coder/requirements.txt
 RUN rm /home/coder/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN sudo wget "https://storage.googleapis.com/kubernetes-release/release/$(curl 
     sudo chmod +x /usr/local/bin/kubectl
 RUN sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc && \
     sudo chmod +x /usr/local/bin/mc
-RUN export PYTHONPATH="${PYTHONPATH}:/home/coder/.local/bin"
-RUN export PATH=/home/coder/.local/bin:$PATH 
+ENV PYTHONPATH="${PYTHONPATH}:/home/coder/.local/bin"
+ENV PATH="/home/coder/.local/bin:${$PATH}"
 ADD requirements.txt /home/coder/requirements.txt
 RUN pip3 install --upgrade -r /home/coder/requirements.txt
 RUN rm /home/coder/requirements.txt


### PR DESCRIPTION
Previous `RUN export` method for setting variables did not work.

Use `ENV` instead.