### PR TITLE
Fix problem with python command not found when using python extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          # push: ${{ github.event_name != 'pull_request' }}
           # Use tags computed before and also latest if on master
           tags: |
             ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,9 @@ jobs:
           # push: ${{ github.event_name != 'pull_request' }}
           # Use tags computed before and also latest if on master
           tags: |
-            ${{ steps.docker_meta.outputs.tags }}
-            ${{ github.ref == 'refs/heads/master' && 'inseefrlab/vscode-python:latest' || '' }}
+#            ${{ steps.docker_meta.outputs.tags }}
+#            ${{ github.ref == 'refs/heads/master' && 'inseefrlab/vscode-python:latest' || '' }}
+            ${{ github.ref == 'refs/heads/alias' && 'inseefrlab/vscode-python:latest' || '' }}
           labels: ${{ steps.docker_meta.outputs.labels }}
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          # push: ${{ github.event_name != 'pull_request' }}
-          # Use tags computed before and also latest if on master
-          tags: |
-            ${{ github.ref == 'refs/heads/alias' && 'inseefrlab/vscode-python:latest' || '' }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
+          push: true
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,6 @@ jobs:
           # push: ${{ github.event_name != 'pull_request' }}
           # Use tags computed before and also latest if on master
           tags: |
-#            ${{ steps.docker_meta.outputs.tags }}
-#            ${{ github.ref == 'refs/heads/master' && 'inseefrlab/vscode-python:latest' || '' }}
             ${{ github.ref == 'refs/heads/alias' && 'inseefrlab/vscode-python:latest' || '' }}
           labels: ${{ steps.docker_meta.outputs.labels }}
       - name: Image digest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
+        if: ${{ github.repository == 'linogaliana/vscode-python' }}
+        id: docker_build
         uses: docker/build-push-action@v2
         with:
-          context: .
-          file: ./Dockerfile
           push: true
+          tags: linogaliana/vscode-python:latest
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,16 +25,21 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        if: ${{ github.repository == 'linogaliana/vscode-python' }}
-        id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: true
-          tags: linogaliana/vscode-python:latest
+          context: .
+          file: ./Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          # Use tags computed before and also latest if on master
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+            ${{ github.ref == 'refs/heads/master' && 'inseefrlab/vscode-python:latest' || '' }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,4 @@ RUN code-server --install-extension redhat.vscode-yaml
 #ADD vscode-settings.json /home/coder/.local/share/code-server/User/settings.json
 
 RUN alias python=python3
-
-echo "alias pip=pip3" >> ~/.bashrc
+RUN echo "alias pip=pip3" >> ~/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,6 @@ RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools
 RUN code-server --install-extension redhat.vscode-yaml  
 #ADD vscode-settings.json /home/coder/.local/share/code-server/User/settings.json
 
-RUN alias python=python3 \
-    && alias pip=pip3
+RUN alias python=python3
+
+echo "alias pip=pip3" >> .bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,3 +29,6 @@ RUN code-server --install-extension ms-python.python
 RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools
 RUN code-server --install-extension redhat.vscode-yaml  
 #ADD vscode-settings.json /home/coder/.local/share/code-server/User/settings.json
+
+RUN alias python=python3 \
+    && alias pip=pip3

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ RUN code-server --install-extension redhat.vscode-yaml
 
 RUN alias python=python3
 
-echo "alias pip=pip3" >> .bashrc
+echo "alias pip=pip3" >> ~/.bashrc

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A docker image based on https://github.com/cdr/code-server tailored for python programming.
 
-It aims to provide a state-of-art IDE with some modules adapted to `Python` to help developers.  
+It aims to provide a state-of-the-art IDE with some modules adapted to `Python` to help developers.  
 
 # How to use it
 
@@ -15,7 +15,13 @@ pd.DataFrame([0, 1, 2])
 
 and press ```SHIFT + ENTER```
 
-Please visit https://github.com/cdr/code-server for knowing how to use this image.
+If you need a package, e.g. `flask`, open a terminal and run 
+
+```shell
+pip install flask
+```
+
+Please visit https://github.com/cdr/code-server to learn how to use this image.
 
 # How to contribute
 If you find something is missing for general python programming with this image, don't hesitate to let us know, either with an issue or by submitting a PR.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,41 @@
 # What is vscode-python?
+
 A docker image based on https://github.com/cdr/code-server tailored for python programming.
 
+It aims to provide a state-of-art IDE with some modules adapted to `Python` to help developers.  
+
 # How to use it
+
+To run a `Python` script in interactive mode, create a new file with `.py` extension, write some commands, e.g. 
+
+```python
+import pandas as pd
+pd.DataFrame([0, 1, 2])
+```
+
+and press ```SHIFT + ENTER```
+
 Please visit https://github.com/cdr/code-server for knowing how to use this image.
 
 # How to contribute
 If you find something is missing for general python programming with this image, don't hesitate to let us know, either with an issue or by submitting a PR.
 
 # Tips
+
 - Use [Settings Sync](https://marketplace.visualstudio.com/items?itemName=Shan.code-settings-sync) to sync up your custom configuration and extension and start a new properly tuned session in a heartbeat.
 - The paste shortcut in the terminal is: ```SHIFT + INSER```
+- To execute code use ```SHIFT + ENTER```
+
+# Run in a local container
+
+First pull the image:
+
+```shell
+docker pull InseeFrLab/vscode-python
+```
+
+```shell
+docker run -it -p 127.0.0.1:8080:8080 -e PASSWORD=test InseeFrLab/vscode-python
+```
+
+:tada: open your browser at `http://localhost:8080/`

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ docker pull InseeFrLab/vscode-python
 ```
 
 ```shell
-docker run -it -p 127.0.0.1:8080:8080 -e PASSWORD=test InseeFrLab/vscode-python
+docker run -it -p 127.0.0.1:8080:8080 -e PASSWORD="YOUR_PASSWORD" InseeFrLab/vscode-python
 ```
 
-:tada: open your browser at `http://localhost:8080/`
+:tada: open your browser at `http://localhost:8080/` and use the password you chose (e.g. `YOUR_PASSWORD`)


### PR DESCRIPTION
`python` and `pip` were not known by vscode. It was expected `python3` and `pip3`. This was problematic for the python extension that was expecting `python`

I propose to use aliases :

*  `python=python3`
* `pip=pip3` (written in `.bashrc` for visual studio terminal to know this alias)