### PR TITLE
Add a python package to handle Vault

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - scikit-learn
   - xgboost
   - pylint
+  - hvac
   - boto3
   - s3fs
   - dvc


### PR DESCRIPTION
`hvac` is a nice way to handle vault secrets. I think this should be available by default