### PR TITLE
add julia extension in vscode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,3 +53,4 @@ RUN code-server --install-extension njpwerner.autodocstring
 RUN code-server --install-extension redhat.vscode-yaml
 RUN code-server --install-extension quarto.quarto
 RUN code-server --install-extension mhutchie.git-graph
+RUN code-server --install-extension julialang.language-julia


### PR DESCRIPTION
Not sure if this is the best way to do since this image is dedicated to python but it would be nice to have access to julia from the datalab